### PR TITLE
Add functionality for toggling visibility of all enabled elements at once and for toggling visibility based on Job Category

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Plugin for XivLauncher/Dalamud that helps you notice when your gear needs to be 
 ## Commands
 
 - `/repairme` - opens the config window
-- `/repairme toggle` - toggle visibility on all RepairMe elements without changing Config
+- `/repairme toggle` - toggle visibility on all enabled RepairMe elements without changing Config
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Plugin for XivLauncher/Dalamud that helps you notice when your gear needs to be 
 ## Commands
 
 - `/repairme` - opens the config window
+- `/repairme toggle` - toggle visibility on all RepairMe elements without changing Config
 
 ## Features
 
@@ -18,7 +19,8 @@ Plugin for XivLauncher/Dalamud that helps you notice when your gear needs to be 
 - Almost all text and background colors can be configured
 
 ## Changelog
-
+* v1.0.1.14
+    * add full visibility toggle command and config checkbox and options for enabling visibility based on Job Category
 * v1.0.1.13
   * remove dependency on XIVCommons
 * v1.0.1.12

--- a/RepairMe/Configuration.cs
+++ b/RepairMe/Configuration.cs
@@ -45,6 +45,8 @@ namespace RepairMe
 
         public bool HideUiWhenOccupied = true;
 
+        public bool ToggleVisibility = true;
+
         // alternative config
         public Dictionary<ulong, string> AltCharacters = new();
 
@@ -53,6 +55,11 @@ namespace RepairMe
         public int ThresholdConditionCritical = 30;
         public int ThresholdConditionLowAlt = 50;
         public int ThresholdConditionCriticalAlt = 30;
+
+        // Job Settings
+        public bool ADV = true;
+        public bool DOL = true;
+        public bool DOH = true;
 
         // bar - condition
         public bool BarConditionEnabled = true;

--- a/RepairMe/EquipmentScanner.cs
+++ b/RepairMe/EquipmentScanner.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using Dalamud.Game;
 using FFXIVClientStructs.FFXIV.Client.Game;
+using Lumina.Excel.GeneratedSheets;
 
 #if DEBUG
 using Dalamud.Logging;
@@ -18,6 +19,8 @@ namespace RepairMe
         public readonly float LowestConditionPercent;
         public readonly float LowestSpiritbondPercent;
         public readonly float HighestSpiritbondPercent;
+        public uint classJob;
+        public byte classJobCategory;
 
         public EquipmentData(uint[] idValues, ushort[] conditionValues, ushort[] spiritbondValues)
         {
@@ -25,6 +28,8 @@ namespace RepairMe
             Condition = new ushort[EquipmentScanner.EquipmentContainerSize];
             Spiritbond = new ushort[EquipmentScanner.EquipmentContainerSize];
             SpiritbondPercents = new float[EquipmentScanner.EquipmentContainerSize];
+            classJob = Dalamud.ClientState.LocalPlayer!.ClassJob.Id;
+            classJobCategory = (byte) Dalamud.GameData.GetExcelSheet<ClassJob>()!.GetRow(classJob)!.ClassJobCategory.Row;
 
             LowestConditionPercent = 60000;
             LowestSpiritbondPercent = 10000;
@@ -79,7 +84,7 @@ namespace RepairMe
             "ring2"
         };
 
-        public Action? NotificationTarget { private get; set; }
+        public System.Action? NotificationTarget { private get; set; }
 
         private InventoryManager* inventoryManager;
         private InventoryContainer* equipmentContainer;

--- a/RepairMe/EquipmentScanner.cs
+++ b/RepairMe/EquipmentScanner.cs
@@ -19,8 +19,8 @@ namespace RepairMe
         public readonly float LowestConditionPercent;
         public readonly float LowestSpiritbondPercent;
         public readonly float HighestSpiritbondPercent;
-        public uint classJob;
-        public byte classJobCategory;
+        //public uint classJob;
+        //public byte classJobCategory;
 
         public EquipmentData(uint[] idValues, ushort[] conditionValues, ushort[] spiritbondValues)
         {
@@ -28,8 +28,8 @@ namespace RepairMe
             Condition = new ushort[EquipmentScanner.EquipmentContainerSize];
             Spiritbond = new ushort[EquipmentScanner.EquipmentContainerSize];
             SpiritbondPercents = new float[EquipmentScanner.EquipmentContainerSize];
-            classJob = Dalamud.ClientState.LocalPlayer!.ClassJob.Id;
-            classJobCategory = (byte) Dalamud.GameData.GetExcelSheet<ClassJob>()!.GetRow(classJob)!.ClassJobCategory.Row;
+            //classJob = Dalamud.ClientState.LocalPlayer!.ClassJob.Id;
+            //classJobCategory = (byte) Dalamud.GameData.GetExcelSheet<ClassJob>()!.GetRow(classJob)!.ClassJobCategory.Row;
 
             LowestConditionPercent = 60000;
             LowestSpiritbondPercent = 10000;

--- a/RepairMe/PluginUI.cs
+++ b/RepairMe/PluginUI.cs
@@ -116,7 +116,7 @@ namespace RepairMe
                 }
 
                 position = positionProfile;
-                classJobCategory = eventHandler.EquipmentScannerLastEquipmentData!.Value.classJobCategory;
+                classJobCategory = (byte) GameData.GetExcelSheet<ClassJob>()!.GetRow(ClientState.LocalPlayer!.ClassJob.Id)!.ClassJobCategory.Row;
 
                 if (SettingsVisible && testingMode)
                 {

--- a/RepairMe/RepairMe.cs
+++ b/RepairMe/RepairMe.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using Dalamud.Game.Command;
+using Dalamud.Logging;
 using Dalamud.Plugin;
 using static RepairMe.Dalamud;
 
@@ -8,8 +9,10 @@ namespace RepairMe
     public sealed class RepairMe : IDalamudPlugin
     {
         private const string CommandName = "/repairme";
+        private const string CommandToggle = "/repairme toggle";
         private EquipmentScanner? equipmentScanner;
         private EventHandler? eventHandler;
+        private Configuration conf => Configuration.GetOrLoad();
 
         private PluginUi? ui;
 
@@ -32,6 +35,11 @@ namespace RepairMe
                 HelpMessage = "RepairMe plugin configuration"
             });
 
+            Commands.AddHandler(CommandToggle, new CommandInfo(OnCommand)
+            {
+                HelpMessage = "Toggle visibility for all enabled RepairMe elements without changing config"
+            });
+
             PluginInterface.UiBuilder.Draw += DrawUi;
             PluginInterface.UiBuilder.OpenConfigUi += DrawConfigUi;
 
@@ -45,13 +53,25 @@ namespace RepairMe
             equipmentScanner?.Dispose();
 
             Commands.RemoveHandler(CommandName);
+            Commands.RemoveHandler(CommandToggle);
             PluginInterface.UiBuilder.Draw -= DrawUi;
             PluginInterface.UiBuilder.OpenConfigUi -= DrawConfigUi;
         }
 
         private void OnCommand(string command, string args)
         {
-            DrawConfigUi();
+            switch (args.ToLower())
+            {
+                case "toggle":
+                    conf!.ToggleVisibility = !conf!.ToggleVisibility;
+                    conf.Save();
+                    break;
+
+                default:
+                    DrawConfigUi();
+                    break;
+
+            }
         }
 
         private void DrawUi()

--- a/RepairMe/RepairMe.csproj
+++ b/RepairMe/RepairMe.csproj
@@ -4,7 +4,7 @@
         <OutputType>Library</OutputType>
         <Authors>Chalkos</Authors>
         <Title>RepairMe</Title>
-        <Version>1.0.1.13</Version>
+        <Version>1.0.1.14</Version>
         <Deterministic>true</Deterministic>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>


### PR DESCRIPTION
Added a checkbox to the top row of Config window and command `/repairme toggle` for toggling visibility of all enabled RepairMe elements without needing to individually toggle each element on/off and a "Job Settings" header with checkboxes for enabling whether RepairMe elements are visible based on Job Category (DoW/M, DoL, and DoH).. Bumped version to 1.0.1.14 and added new command to ReadMe..